### PR TITLE
fix(aes): allow connect-src to Render backend in CSP

### DIFF
--- a/pages/aes-tool.html
+++ b/pages/aes-tool.html
@@ -19,7 +19,7 @@
 
         All other directives (script-src, connect-src, object-src) are unchanged.
     -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://aes-tool-backend.onrender.com">
     <title>AES Image Encryption - Cryptography Portfolio</title>
 
     <!-- Link to main stylesheets -->


### PR DESCRIPTION
# Summary                                                                                                                              
   
- The AES tool's Content Security Policy was blocking fetch() calls to the Render backend — default-src 'self' covers connect-src by default, rejecting any external origin
- Adds an explicit connect-src 'self' https://aes-tool-backend.onrender.com directive to pages/aes-tool.html

# Test plan

- Open the AES tool and encrypt an image — confirm no CSP errors in the browser console
- Confirm the other tool pages (rsa-tool, hash-tool, ec-tool) are unaffected