### PR TITLE
fix(aes): fix encryption-decryption roundtrip broken with large images

### DIFF
--- a/backend/app/routes/aes.py
+++ b/backend/app/routes/aes.py
@@ -12,8 +12,8 @@ logger = logging.getLogger(__name__)
 from fastapi.responses import JSONResponse
 
 from app.validation import (
-    validate_file_size, validate_iv, validate_key_hex, validate_key_length,
-    validate_mime_type, validate_mode,
+    validate_decrypt_file_size, validate_file_size, validate_iv, validate_key_hex,
+    validate_key_length, validate_mime_type, validate_mode,
 )
 
 router = APIRouter(prefix="/api")
@@ -115,7 +115,7 @@ async def decrypt(
 ):
     mime       = validate_mime_type(image.content_type or "")
     data       = await image.read()
-    validate_file_size(len(data))
+    validate_decrypt_file_size(len(data))
     key_length = validate_key_length(key_length)
     key        = validate_key_hex(key, key_length)
 

--- a/backend/app/validation.py
+++ b/backend/app/validation.py
@@ -4,7 +4,8 @@ from fastapi import HTTPException
 ALLOWED_MODES       = {"ECB", "CBC", "OFB", "CTR"}
 ALLOWED_KEY_LENGTHS = {128, 192, 256}
 ALLOWED_MIME_TYPES  = {"image/bmp", "image/png", "image/jpeg"}
-MAX_FILE_SIZE_BYTES = 8 * 1024 * 1024   # 8 MB
+MAX_FILE_SIZE_BYTES         = 8 * 1024 * 1024   # 8 MB
+MAX_DECRYPT_FILE_SIZE_BYTES = 64 * 1024 * 1024  # 64 MB
 HEX_IV_PATTERN      = re.compile(r'^[0-9A-Fa-f]{32}$')
 
 def validate_mode(mode: str) -> str:
@@ -39,6 +40,10 @@ def validate_key_hex(key: str, key_length: int) -> str:
 def validate_file_size(size: int) -> None:
     if size > MAX_FILE_SIZE_BYTES:
         raise HTTPException(413, "File exceeds maximum allowed size of 8 MB")
+
+def validate_decrypt_file_size(size: int) -> None:
+    if size > MAX_DECRYPT_FILE_SIZE_BYTES:
+        raise HTTPException(413, "File exceeds maximum allowed size of 64 MB")
 
 def validate_mime_type(content_type: str) -> str:
     base_type = content_type.split(";")[0].strip().lower()

--- a/src/crypto-demos/aes/aes-display.ts
+++ b/src/crypto-demos/aes/aes-display.ts
@@ -206,6 +206,13 @@ function jpgCalloutHtml(): string {
     );
 }
 
+function sizeInflationCalloutHtml(): string {
+    return `<div class="callout callout--info">
+        <strong>Note on file size:</strong> Encrypted images are typically larger than their originals.
+        AES produces near-random data that compresses poorly — this is a sign of good encryption.
+    </div>`;
+}
+
 // ============================================================================
 // PUBLIC DISPLAY FUNCTIONS
 // ============================================================================
@@ -233,6 +240,7 @@ export function displayEncryptionResult(
 
         ${showEcbCallout ? ecbCalloutHtml() : ''}
         ${showJpgCallout ? jpgCalloutHtml() : ''}
+        ${sizeInflationCalloutHtml()}
 
         ${keyMaterialHtml(response)}
         ${decryptFormHtml(response)}


### PR DESCRIPTION
## Problem

AES encryption converts image pixels into high-entropy, near-random data. When re-encoded as PNG, compression achieves almost nothing — random data has no redundancy to exploit. As a result, encrypted PNGs can be significantly larger than the original compressed file.

The `/decrypt` endpoint reused the same `validate_file_size()` check as `/encrypt` (8 MB limit). Uploading a large encrypted image (e.g. from a ~6–8 MB JPEG source) would trigger a **HTTP 413** response, breaking the encrypt → decrypt roundtrip entirely.

## Solution

### Backend (`backend/app/validation.py`, `backend/app/routes/aes.py`)
- Added a dedicated `MAX_DECRYPT_FILE_SIZE_BYTES = 64 MB` constant and `validate_decrypt_file_size()` function.
- The `/decrypt` handler now uses `validate_decrypt_file_size()` instead of `validate_file_size()`.
- The `/encrypt` endpoint is unchanged — the 8 MB upload limit remains in place.

### Frontend (`src/crypto-demos/aes/aes-display.ts`)
- Added a `sizeInflationCalloutHtml()` helper that returns an informational callout.
- The callout is always rendered in the encryption result panel, explaining why encrypted files are larger and framing it as a property of good encryption.

This solves issue #12 

## Test plan
- [ ] Upload a large JPEG (~6–8 MB) and encrypt it — the encrypted PNG downloads successfully even if > 8 MB.
- [ ] Submit the encrypted image for decryption — succeeds without a 413 error.
- [ ] Confirm the size inflation note appears in the encryption result panel.
- [ ] Confirm the encrypt endpoint still rejects files >8 MB (existing behaviour unchanged).

## Commits

- **fix(aes): raise decrypt size limit to 64 MB**
- **feat(aes): add size inflation callout to encryption result**
