### PR TITLE
feat: rename repo to security-portfolio and update all URL references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Mathematical Foundations
+# Security Portfolio
 
-Web pages showcasing my projects on mathematics, cryptography, and computer science, and hosting interactive tools.
+Security portfolio showcasing cryptography concepts and projects, with interactive tools for AES, RSA, hashing, and elliptic curves.
 
 ## Table of Contents
 - [About the Project](#about-the-project)
@@ -31,12 +31,12 @@ To run the projects locally, follow these steps:
 
 1. **Clone the repository**
    ```bash
-   git clone https://github.com/fer-osorio/mathematical-foundations.git
+   git clone https://github.com/fer-osorio/security-portfolio.git
    ```
 
 2. **Navigate to the project directory**
    ```bash
-   cd mathematical-foundations
+   cd security-portfolio
    ```
 
 3. **Open the HTML files in your browser**

--- a/assets/favicon/site.webmanifest
+++ b/assets/favicon/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "mathematical-foundations",
-  "short_name": "math-found",
+  "name": "Security Portfolio",
+  "short_name": "sec-portfolio",
   "icons": [
     {
       "src": "/assets/web-app-manifest-192x192.png",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,7 +3,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.routes.aes import router as aes_router
 
-app = FastAPI(title="Mathematical Foundations — Backend")
+app = FastAPI(title="Security Portfolio — Backend")
 
 origins = os.environ.get("ALLOWED_ORIGINS", "http://localhost:5173").split(",")
 

--- a/index.html
+++ b/index.html
@@ -14,8 +14,8 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'">
 
     <!-- SEO & METADATA -->
-    <meta name="description" content="Interactive demonstrations of mathematical concepts in cryptography, algorithms, and computer science. Built by a mathematician and cryptographer.">
-    <meta name="keywords" content="mathematics, cryptography, algorithms, RSA, number theory, computer science, interactive learning">
+    <meta name="description" content="Security portfolio showcasing cryptography concepts and projects. Interactive tools for AES, RSA, hashing, and elliptic curves.">
+    <meta name="keywords" content="cybersecurity, cryptography, security portfolio, AES, RSA, elliptic curves, hashing, interactive tools">
     <meta name="author" content="Alexis Fernando Osorio Sarabio">
 
     <!-- ===================================================================
@@ -26,16 +26,16 @@
          =================================================================== -->
 
     <!-- Primary Open Graph tags -->
-    <meta property="og:title" content="Mathematical Foundations - Cryptography & Algorithms">
-    <meta property="og:description" content="From theory to implementation: explore cryptography, number theory, and computational complexity through interactive demonstrations.">
+    <meta property="og:title" content="Security Portfolio - Cryptography & Cybersecurity">
+    <meta property="og:description" content="A security portfolio showcasing cryptography concepts through interactive demonstrations and projects.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://fer-osorio.github.io/mathematical-foundations/">
-    <meta property="og:image" content="https://fer-osorio.github.io/mathematical-foundations/assets/images/piandphi.png">
+    <meta property="og:url" content="https://fer-osorio.github.io/security-portfolio/">
+    <meta property="og:image" content="https://fer-osorio.github.io/security-portfolio/assets/images/piandphi.png">
     <!-- Additional Open Graph tags (optional but recommended) -->
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta property="og:image:alt" content="Mathematical Foundations logo - Pi and Phi symbols with cryptography and mathematics">
-    <meta property="og:site_name" content="Mathematical Foundations">
+    <meta property="og:image:alt" content="Security Portfolio logo">
+    <meta property="og:site_name" content="Security Portfolio">
     <meta property="og:locale" content="en_US">
 
     <!-- Favicon settup -->
@@ -46,7 +46,7 @@
     <link rel="manifest" href="assets/favicon/site.webmanifest" />
 
 
-    <title>Mathematical Foundations - Cryptography, Algorithms & Theory</title>
+    <title>Security Portfolio - Cryptography & Cybersecurity</title>
     <link rel="stylesheet" href="css/main.css">
     <link rel="stylesheet" href="css/pages/home.css">
 </head>
@@ -60,7 +60,7 @@
                 <div class="logo">
                     <span class="symbol">ΠΦ</span>
                     <div class="text">
-                        <span class="main">Mathematical Foundations</span>
+                        <span class="main">Security Portfolio</span>
                         <span class="sub">THEORY • IMPLEMENTATION • SECURITY</span>
                     </div>
                 </div>
@@ -82,7 +82,7 @@
         <!-- HERO SECTION: Introductory content -->
         <section class="hero">
             <div class="hero-content">
-                <h1>Mathematical Foundations</h1>
+                <h1>Security Portfolio</h1>
                 <p>From theory to implementation: exploring mathematics, cryptography, and computational complexity</p>
                 <p class="subtitle">
                 A mathematician isn't defined by a degree, but by a willingness to explore. A mathematician is anyone ready to dive into the world of ideas, equipped with nothing more than curiosity—and perhaps a place to scribble.
@@ -278,7 +278,7 @@
     </main>
 
     <footer>
-        <p>&copy; 2025 Mathematical Foundations. All rights reserved.</p>
+        <p>&copy; 2025 Security Portfolio. All rights reserved.</p>
         <p class="security-note">
             Interactive demonstrations for educational purposes.
             <a href="#about">Learn more about this project.</a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "mathematical-foundations",
+  "name": "security-portfolio",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mathematical-foundations",
+      "name": "security-portfolio",
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "mathematical-foundations",
+  "name": "security-portfolio",
   "version": "1.0.0",
-  "description": "Web pages showcasing my projects on mathematics, cryptography, and computer science, and hosting interactive tools.",
+  "description": "Security portfolio showcasing cryptography concepts and interactive tools.",
   "main": "index.js",
   "directories": {
     "doc": "docs",
@@ -20,14 +20,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/fer-osorio/mathematical-foundations.git"
+    "url": "git+https://github.com/fer-osorio/security-portfolio.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/fer-osorio/mathematical-foundations/issues"
+    "url": "https://github.com/fer-osorio/security-portfolio/issues"
   },
-  "homepage": "https://github.com/fer-osorio/mathematical-foundations#readme",
+  "homepage": "https://github.com/fer-osorio/security-portfolio#readme",
   "devDependencies": {
     "@types/crypto-js": "^4.2.2",
     "@vitest/coverage-v8": "^4.1.2",

--- a/pages/aes-tool.html
+++ b/pages/aes-tool.html
@@ -20,7 +20,7 @@
         All other directives (script-src, connect-src, object-src) are unchanged.
     -->
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://aes-tool-backend.onrender.com">
-    <title>AES Image Encryption - Cryptography Portfolio</title>
+    <title>AES Image Encryption - Security Portfolio</title>
 
     <!-- Link to main stylesheets -->
     <link rel="stylesheet" href="../css/main.css">
@@ -121,7 +121,7 @@
     </main>
 
     <footer>
-        <p>&copy; 2025 Cryptography Portfolio. Educational demonstration only.</p>
+        <p>&copy; 2025 Security Portfolio. Educational demonstration only.</p>
         <p class="alert alert--security-note">
             <strong>⚠️ Security Notice:</strong> This is a teaching tool. Never use for real cryptographic applications.
             Always use audited, standard cryptographic libraries in production.

--- a/pages/ec-tool.html
+++ b/pages/ec-tool.html
@@ -7,7 +7,7 @@
             http-equiv="Content-Security-Policy"
             content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'"
         />
-        <title>Elliptic Curve Explorer - Cryptography Portfolio</title>
+        <title>Elliptic Curve Explorer - Security Portfolio</title>
 
         <!-- Link to main stylesheets -->
         <link rel="stylesheet" href="../css/main.css" />
@@ -1102,7 +1102,7 @@ Hello, ECDSA! This message is authentic.</textarea
 
         <footer>
             <p>
-                &copy; 2025 Cryptography Portfolio. Educational demonstration
+                &copy; 2025 Security Portfolio. Educational demonstration
                 only.
             </p>
             <p class="alert alert--security-note">

--- a/pages/hash-tool.html
+++ b/pages/hash-tool.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline'">
-    <title>Hash Function Visualizer - Cryptography Portfolio</title>
+    <title>Hash Function Visualizer - Security Portfolio</title>
 
     <!-- Link to stylesheets -->
     <link rel="stylesheet" href="../css/main.css">
@@ -228,7 +228,7 @@
     </main>
 
     <footer>
-        <p>&copy; 2025 Cryptography Portfolio. Educational demonstration only.</p>
+        <p>&copy; 2025 Security Portfolio. Educational demonstration only.</p>
     </footer>
 
     <script type="module" src="/src/crypto-demos/hash/hash-demo.ts"></script>

--- a/pages/rsa-tool.html
+++ b/pages/rsa-tool.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'">
-    <title>RSA Interactive Tool - Cryptography Portfolio</title>
+    <title>RSA Interactive Tool - Security Portfolio</title>
 
     <!-- Link to main stylesheets -->
     <link rel="stylesheet" href="../css/main.css">
@@ -202,7 +202,7 @@
     </main>
 
     <footer>
-        <p>&copy; 2025 Cryptography Portfolio. Educational demonstration only.</p>
+        <p>&copy; 2025 Security Portfolio. Educational demonstration only.</p>
         <p class="alert alert--security-note">
             <strong>⚠️ Security Notice:</strong> This is a teaching tool. Never use for real cryptographic applications.
             Always use audited, standard cryptographic libraries in production.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  base: '/mathematical-foundations/',
+  base: '/security-portfolio/',
   root: '.',
   build: {
     outDir: 'dist',


### PR DESCRIPTION
# Summary

Completes the repository rename from mathematical-foundations to security-portfolio, updating all hardcoded references throughout the  codebase.
                                                                                                                                       
- Updates vite.config.ts base path so assets are served from the new GitHub Pages URL                                                
- Updates package.json, package-lock.json, index.html (og:url / og:image), and README.md with the new repo name and URLs
- Rebrands remaining UI text in page titles, footers, the web app manifest, and the backend FastAPI title from "Cryptography Portfolio" to "Security Portfolio"

# Test plan

- GitHub Actions deploy.yml run completes successfully after merge
- https://fer-osorio.github.io/security-portfolio/ loads with correct assets (no 404 on JS/CSS)
- Each tool page (/pages/*.html) loads correctly
- og:url and og:image in devtools Elements panel point to the new URL