### PR TITLE
Refactor/ec small curves

### DIFF
--- a/pages/ec-tool.html
+++ b/pages/ec-tool.html
@@ -453,8 +453,7 @@
                     <div class="form-group">
                         <label for="ecdh-curve-select">Select Curve:</label>
                         <select id="ecdh-curve-select">
-                            <!-- Option with bugs, commented for addition in the future.
-                            <option value="test-small">Test Curve (p = 23) - See all steps</option> -->
+                            <option value="test-small">Test Curve (p = 29) - See all steps</option>
                             <option value="secp256k1" selected>
                                 secp256k1 (Bitcoin)
                             </option>

--- a/src/crypto-demos/ec/ec-core.ts
+++ b/src/crypto-demos/ec/ec-core.ts
@@ -458,16 +458,19 @@ export class ECDSA {
     // Step 1: Hash message
     const h = await this._hashMessage(message);
 
-    // Step 2: Generate deterministic k (simplified RFC 6979)
-    const k = await this._generateNonce(privateKey, h);
+    let k = 0n; // Deterministic nonce
+    let R;
+    let r = 0n;
+    let attempt = 0;
 
-    // Step 3: Compute R = kG
-    const R = scalarMultiplySecure(k, this.curve.G);
-    const r = R.x % this.curve.n;
-
-    // Check r ≠ 0 (negligible probability)
-    if (r === 0n) {
-      throw new Error("Signature generation failed: r = 0 (regenerate k)");
+    // Check r ≠ 0 (negligible probability for standard curves, non-negligible for small curves).
+    // Pass an attempt counter so each retry feeds different input to HMAC, producing a new k.
+    while (r === 0n) {
+      // Step 2: Generate deterministic k (simplified RFC 6979)
+      k = await this._generateNonce(privateKey, h, attempt++);
+      // Step 3: Compute R = kG
+      R = scalarMultiplySecure(k, this.curve.G);
+      r = R.x % this.curve.n;
     }
 
     // Step 4: Compute s = k⁻¹(h + r·d) mod n
@@ -580,15 +583,17 @@ export class ECDSA {
   private async _generateNonce(
     privateKey: bigint,
     messageHash: bigint,
+    attempt = 0,
   ): Promise<bigint> {
     // Convert inputs to byte arrays
     const keyBytes = this._bigIntToBytes(privateKey);
     const hashBytes = this._bigIntToBytes(messageHash);
 
-    // Concatenate for HMAC input
-    const combined = new Uint8Array(keyBytes.length + hashBytes.length);
+    // Concatenate for HMAC input; include attempt counter so retries produce a different k
+    const combined = new Uint8Array(keyBytes.length + hashBytes.length + 1);
     combined.set(keyBytes, 0);
     combined.set(hashBytes, keyBytes.length);
+    combined[keyBytes.length + hashBytes.length] = attempt & 0xff;
 
     // Import key for HMAC
     const hmacKey = await crypto.subtle.importKey(

--- a/src/crypto-demos/ec/ec-core.ts
+++ b/src/crypto-demos/ec/ec-core.ts
@@ -258,19 +258,19 @@ const P256 = new EllipticCurve(
 );
 
 /**
- * Small test curve E(F₂₃): y² = x³ + 7 (mod 23) — for educational demos only
- * Generator G = (6, 4), group order n = 28, cofactor h = 1
+ * Small test curve E(F₂₉): y² = x³ + x + 12 (mod 29) — for educational demos only
+ * Generator G = (4, 15), group order n = 23 (prime, cyclic), cofactor h = 1
  */
-let testF23: EllipticCurve | null = null;
+let ecP29a1b12: EllipticCurve | null = null;
 try {
-  testF23 = new EllipticCurve(
-    "Test-F23",
-    97n,
-    2n,
-    3n,
-    { x: 3n, y: 6n },
-    5n,
-    20n,
+  ecP29a1b12 = new EllipticCurve(
+    "ec-p29a1b12",
+    29n,
+    1n,
+    12n,
+    { x: 4n, y: 15n },
+    23n,
+    1n,
   );
 } catch (e) {
   console.warn("Test curve initialization failed:", e);
@@ -286,9 +286,9 @@ const CURVES: Record<string, EllipticCurve> = {
   secp256r1: P256, // Alias
 };
 
-if (testF23) {
-  CURVES["test-small"] = testF23;
-  CURVES["Test-F23"] = testF23;
+if (ecP29a1b12) {
+  CURVES["test-small"] = ecP29a1b12;
+  CURVES["ec-p29a1b12"] = ecP29a1b12;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Replace the placeholder test curve (`Test-F23`, which had incorrect parameters) with the verified cyclic curve `ec p29a1b12`: E(F₂₉): y² = x³ + x + 12 (mod 29), group order n = 23 (prime), generator (4, 15)
- Fix an infinite loop in `ECDSA.sign` when `r = 0` — a non-negligible probability on small curves — by introducing an attempt counter into the nonce derivation so each retry produces a different `k`
- Uncomment the small test curve option in the ECDH UI now that the underlying curve is valid

## Test plan

- [ ] ECDSA sign/verify round-trip passes for all three curves (`secp256k1`, `P-256`, `ec-p29a1b12`)
- [ ] Deterministic signing test passes: same key + message always produces the same `(r, s)`
- [ ] Run the full test suite multiple times to confirm no flaky failures on the small curve
- [ ] Verify the test curve option appears and functions correctly in the ECDH section of `ec-tool.html`